### PR TITLE
fix/refactor: correctly handle returning NOK frames

### DIFF
--- a/pkg/proto/firmware_cmd.go
+++ b/pkg/proto/firmware_cmd.go
@@ -1,6 +1,7 @@
 package proto
 
 var (
+	RspFirmwareError    = FirmwareCmd{0x00, "rspFirmwareError", CmdLen1}
 	CmdGetNameVersion   = FirmwareCmd{0x01, "cmdGetNameVersion", CmdLen1}
 	RspGetNameVersion   = FirmwareCmd{0x02, "rspGetNameVersion", CmdLen32}
 	CmdLoadApp          = FirmwareCmd{0x03, "cmdLoadApp", CmdLen128}


### PR DESCRIPTION
This PR  correctly handle returning NOK frames when needed, and also adds `FirmwareErrorFrame` and `AppErrorFrame` types to make this easier.