### PR TITLE
bugfix: correctly handle state in signing app and correct test cases

### DIFF
--- a/examples/blinker/app/blinker_test.go
+++ b/examples/blinker/app/blinker_test.go
@@ -46,7 +46,7 @@ func TestHandleCommand(t *testing.T) {
 			frame.Read(rx)
 
 			err := handleCommand(rx, tx)
-			if err != nil && !tt.hasError {
+			if err != nil && !tt.hasError || (err == nil && tt.hasError) {
 				t.Errorf("handleCommand(%v) = %v, want %v", tt.cmd, err, tt.hasError)
 			}
 		})

--- a/examples/signer/app/loading.go
+++ b/examples/signer/app/loading.go
@@ -6,6 +6,8 @@ import (
 
 func handleLoadingCommand(rx []byte, tx []byte) (err error) {
 	var response proto.Frame
+	var invalidCommand bool
+
 	hdr, err := proto.ParseFramingHdr(rx[0])
 	if err != nil {
 		return err
@@ -21,7 +23,7 @@ func handleLoadingCommand(rx []byte, tx []byte) (err error) {
 
 	default:
 		response, err = proto.AppErrorFrame(int(hdr.ID))
-
+		invalidCommand = true
 	}
 
 	if err != nil {
@@ -33,6 +35,10 @@ func handleLoadingCommand(rx []byte, tx []byte) (err error) {
 
 	// write tx buffer with response
 	uart.Write(tx[:response.Len()+1])
+
+	if invalidCommand {
+		return errInvalidCommand
+	}
 
 	return nil
 }

--- a/examples/signer/app/signer.go
+++ b/examples/signer/app/signer.go
@@ -18,6 +18,9 @@ const (
 )
 
 var (
+	errInvalidCommand = errors.New("invalid command")
+	errInvalidMessage = errors.New("invalid message buffer")
+
 	currentState state = stateStarted
 	publicKey    ed25519.PublicKey
 	privateKey   ed25519.PrivateKey

--- a/examples/signer/app/signer_test.go
+++ b/examples/signer/app/signer_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/hybridgroup/tinygo-tkey/pkg/proto"
+)
+
+func TestHandleStartedCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      proto.AppCmd
+		id       int
+		data     []byte
+		hasError bool
+	}{
+		{
+			name:     "cmdGetPublicKey",
+			cmd:      cmdGetPublicKey,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: false,
+		},
+		{
+			name:     "cmdGetNameVersion",
+			cmd:      cmdGetNameVersion,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: false,
+		},
+		{
+			name:     "cmdSetSize",
+			cmd:      cmdSetSize,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: false,
+		},
+		{
+			name:     "cmdGetSig",
+			cmd:      cmdGetSig,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+		{
+			name:     "cmdLoadData",
+			cmd:      cmdLoadData,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		rx := make([]byte, 256)
+		tx := make([]byte, 256)
+
+		t.Run(tt.name, func(t *testing.T) {
+			currentState = stateStarted // Reset state for next test
+
+			frame, _ := proto.NewFrame(tt.cmd, tt.id, tt.data)
+			frame.Read(rx)
+
+			err := handleCommand(rx, tx)
+			if err != nil && !tt.hasError || (err == nil && tt.hasError) {
+				t.Errorf("handleCommand(%v) = %v, want %v", tt.cmd, err, tt.hasError)
+			}
+		})
+	}
+}
+
+func TestHandleLoadingCommands(t *testing.T) {
+	generateKeys()
+
+	tests := []struct {
+		name     string
+		cmd      proto.AppCmd
+		id       int
+		data     []byte
+		hasError bool
+	}{
+		{
+			name:     "cmdLoadData",
+			cmd:      cmdLoadData,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: false,
+		},
+		{
+			name:     "cmdGetPublicKey",
+			cmd:      cmdGetPublicKey,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+		{
+			name:     "cmdGetNameVersion",
+			cmd:      cmdGetNameVersion,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		rx := make([]byte, 256)
+		tx := make([]byte, 256)
+
+		t.Run(tt.name, func(t *testing.T) {
+			currentState = stateLoading // Reset state for next test
+			frame, _ := proto.NewFrame(tt.cmd, tt.id, tt.data)
+			frame.Read(rx)
+
+			err := handleCommand(rx, tx)
+			if err != nil && !tt.hasError || (err == nil && tt.hasError) {
+				t.Errorf("handleCommand(%v) = %v, want %v", tt.cmd, err, tt.hasError)
+			}
+		})
+	}
+}
+
+func TestHandleSigningCommands(t *testing.T) {
+	generateKeys()
+
+	tests := []struct {
+		name     string
+		cmd      proto.AppCmd
+		id       int
+		data     []byte
+		hasError bool
+	}{
+		{
+			name:     "cmdGetSig",
+			cmd:      cmdGetSig,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: false,
+		},
+		{
+			name:     "cmdGetPublicKey",
+			cmd:      cmdGetPublicKey,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+		{
+			name:     "cmdGetNameVersion",
+			cmd:      cmdGetNameVersion,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+		{
+			name:     "cmdLoadData",
+			cmd:      cmdLoadData,
+			id:       2,
+			data:     []byte{0x00},
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		rx := make([]byte, 256)
+		tx := make([]byte, 256)
+
+		t.Run(tt.name, func(t *testing.T) {
+			currentState = stateSigning // Reset state for next test
+			frame, _ := proto.NewFrame(tt.cmd, tt.id, tt.data)
+			frame.Read(rx)
+
+			err := handleCommand(rx, tx)
+			if err != nil && !tt.hasError || (err == nil && tt.hasError) {
+				t.Errorf("handleCommand(%v) = %v, want %v", tt.cmd, err, tt.hasError)
+			}
+		})
+	}
+}

--- a/examples/signer/app/signing.go
+++ b/examples/signer/app/signing.go
@@ -6,6 +6,11 @@ import (
 
 func handleSigningCommand(rx []byte, tx []byte) (err error) {
 	var response proto.Frame
+	var invalidCommand bool
+	if len(message) < messageSize {
+		return errInvalidMessage // not enough data to sign
+	}
+
 	hdr, err := proto.ParseFramingHdr(rx[0])
 	if err != nil {
 		return err
@@ -22,7 +27,7 @@ func handleSigningCommand(rx []byte, tx []byte) (err error) {
 
 	default:
 		response, err = proto.AppErrorFrame(int(hdr.ID))
-
+		invalidCommand = true
 	}
 
 	if err != nil {
@@ -34,6 +39,10 @@ func handleSigningCommand(rx []byte, tx []byte) (err error) {
 
 	// write tx buffer with response
 	uart.Write(tx[:response.Len()+1])
+
+	if invalidCommand {
+		return errInvalidCommand
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR provides a fix for an issue with the signer app and the expected states.

While increasing test coverage for apps, I discovered that invalid commands were not triggering the expected error cases during the tests. This was due to not fully handling the signing app device state when being sent invalid commands for that state.

It was also due to the tests not correctly looking at the expected error if one was expected. This PR also corrects that.