### PR TITLE
make: add tasks to makefile for flashing and building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pub
 *.sig
+build

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
 
-.PHONY: blinker-app
-blinker-app:
+build:
+	mkdir -p build
+
+.PHONY: build-blinker-app
+build-blinker-app: build
+	tinygo build -o ./build/blinker-app.hex -size short -target=tkey ./examples/blinker/app
+
+.PHONY: flash-blinker-app
+flash-blinker-app:
 	tinygo flash -size short -target=tkey ./examples/blinker/app
 
 .PHONY: blinker-cmd
 blinker-cmd:
 	go run ./examples/blinker/cmd
+
+.PHONY: build-signer-app
+build-signer-app:
+	tinygo build -o ./build/signer-app.hex -size short -target=tkey ./examples/signer/app
+
+.PHONY: flash-signer-app
+flash-signer-app:
+	tinygo flash -size short -target=tkey ./examples/signer/app
 
 .PHONY: test
 test:


### PR DESCRIPTION
This PR add tasks to the makefile for flashing and building, for both the blinker and signer apps.

Makes it easier to run, and also will make it easier for CI setup.